### PR TITLE
[Resizable Cell][Size invalidation]: Check if cell is still in the collection view

### DIFF
--- a/Source/List/ListModelSectionController.swift
+++ b/Source/List/ListModelSectionController.swift
@@ -325,7 +325,7 @@ extension ListModelSectionController: ListDisplayDelegate {
 
 extension ListModelSectionController: ListResizableCellDelegate {
   internal func cellDidInvalidateSize(_ cell: ListResizableCell) {
-    guard let index = collectionContext?.index(for: cell, sectionController: self) else { return }
+    guard let index = collectionContext?.index(for: cell, sectionController: self), index != NSNotFound else { return }
     let indexPath = IndexPath(item: index, section: section)
     delegate?.sectionController(self, didInvalidateSizeAt: indexPath)
   }


### PR DESCRIPTION
I've recently encountered a crash which had to do with removing a section which was a first responder.
In my stack traces `let index` was `9223372036854775807` which is `NSNotFound`.

I suspect in my case cell was already out of collection view so trying to reload it caused a crash.