### PR TITLE
[Resizable Cell][Size invalidation]: Crash on trying to reload removed section

### DIFF
--- a/MinervaTests/Tests/ListTests.swift
+++ b/MinervaTests/Tests/ListTests.swift
@@ -283,6 +283,8 @@ public final class ListTests: CommonSetupTestCase {
     }
 
     XCTAssertEqual(cell.bounds.size, size1)
+
+    listController.willDisplay()
     XCTAssertNotNil(cell.resizableDelegate)
 
     cellModel.size = ListCellSize.explicit(size: size2)

--- a/Source/List/ListModelSectionController.swift
+++ b/Source/List/ListModelSectionController.swift
@@ -133,9 +133,6 @@ extension ListModelSectionController {
       assertionFailure("Failed to load the reuseable cell for \(cellType)")
       return MissingListCell()
     }
-    if let cell = cell as? ListResizableCell {
-      cell.resizableDelegate = self
-    }
     return cell
   }
 
@@ -306,6 +303,9 @@ extension ListModelSectionController: ListDisplayDelegate {
     cell: UICollectionViewCell,
     at index: Int
   ) {
+    if let resizableCell = cell as? ListResizableCell {
+        resizableCell.resizableDelegate = self
+    }
     guard let minervaCell = cell as? ListDisplayableCell else { return }
     minervaCell.willDisplayCell()
   }
@@ -316,6 +316,9 @@ extension ListModelSectionController: ListDisplayDelegate {
     cell: UICollectionViewCell,
     at index: Int
   ) {
+    if let resizableCell = cell as? ListResizableCell {
+        resizableCell.resizableDelegate = nil
+    }
     guard let minervaCell = cell as? ListDisplayableCell else { return }
     minervaCell.didEndDisplayingCell()
   }


### PR DESCRIPTION
Cell is being reused, but its section controller isn't set to the right one.
That would happen if the cell is reused and the list section is recreated.