### PR TITLE
List sections in reload data

### DIFF
--- a/Source/List/LegacyListController.swift
+++ b/Source/List/LegacyListController.swift
@@ -70,7 +70,12 @@ public final class LegacyListController: NSObject, ListController {
 
   public func reloadData(completion: Completion?) {
     dispatchPrecondition(condition: .onQueue(.main))
-    reloadData(completion: completion, enqueueIfNeeded: true)
+    reloadData(completion: completion, enqueueIfNeeded: true, listSections: nil)
+  }
+  
+  public func reloadData(listSections: [ListSection], completion: Completion?) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    reloadData(completion: completion, enqueueIfNeeded: true, listSections: listSections)
   }
 
   public func update(with listSections: [ListSection], animated: Bool, completion: Completion?) {

--- a/Source/List/LegacyListController.swift
+++ b/Source/List/LegacyListController.swift
@@ -241,12 +241,15 @@ public final class LegacyListController: NSObject, ListController {
     }
   }
 
-  private func reloadData(completion: Completion?, enqueueIfNeeded: Bool) {
+  private func reloadData(completion: Completion?, enqueueIfNeeded: Bool, listSections: [ListSection]? = nil) {
     guard !enqueueIfNeeded || (actionQueue.isEmpty && !updating) else {
       actionQueue.append(.reloadData(completion: completion))
       return
     }
     updating = true
+    if let listSections = listSections {
+      listSectionWrappers = listSections.map(ListSectionWrapper.init)
+    }
     adapter.reloadData { [weak self] finished in
       defer {
         completion?(finished)

--- a/Source/List/ListController.swift
+++ b/Source/List/ListController.swift
@@ -41,6 +41,12 @@ public protocol ListController: AnyObject {
   /// - Parameter completion: A block to execute when the reload completes.
   func reloadData(completion: Completion?)
 
+  /// Replaces the existing list sections with those specified and reloads all cells on the collection view
+  /// - Parameters:
+  ///   - listSections: The sections to bind to the collection view.
+  ///   - completion: A block to execute when the reload completes.
+  func reloadData(listSections: [ListSection], completion: Completion?)
+
   /// Replaces the existing list sections with those specified. If a CellModel has the same identifier it will be updated if identical evaluates to false, otherwise
   /// The newly provided CellModel is ignored.
   /// - Parameters:


### PR DESCRIPTION
Please, refer to: [IGListKit Best Practices](https://instagram.github.io/IGListKit/best-practices-and-faq.html)

> I have a huge data set and -performUpdatesAnimated: completion: is super slow. What do I do?
> If you have multiple thousands of items and you cannot batch them in, you’ll see performance issues with -performUpdatesAnimated: completion:. The real bottleneck behind the scenes here is UICollectionView attempting to insert so many cells at once. Instead, call -reloadDataWithCompletion: when you first load data. Behind the scenes, this method does not do any diffing and simply calls -reloadData on UICollectionView. For subsequent updates, you can then use -performUpdatesAnimated: completion:.

Right now the only way to update listSections is Minerva is through "update" method of ListController.
And unfortunately it uses "-performUpdatesAnimated: completion:" under the hood and that's why is extremely slow on huge sets of data. There’s simply no way to update listSections and call "-reloadDataWithCompletion:" as mentioned in IGListKit Best Practices, so in this PR I added a way to do this.
I confirmed that if it’s used on initial load for huge sets of data (> 100K items) it can give > 5x performance boost